### PR TITLE
Error corrected that causes the expectation value to be calculated incorrectly

### DIFF
--- a/src/dense_ev/rmatrix.py
+++ b/src/dense_ev/rmatrix.py
@@ -196,8 +196,13 @@ def get_groups2(H, m):
     """
     # Will primitive.paulis include the full set irrespective of H?
     id_list = [str(x) for x in primitive.paulis]
-    id_dict = {id_list[x]: x for x in range(len(id_list))}
-    # print('id_dict:', id_dict)
+    
+    ## all the Pauli operators with a coefficient equal to zero in the decomposition are converted into the identity,
+    ## so, we have to save the pointer to the "true" coefficient associated to the identity (otherwise, it will be zero)
+    identity_string = id_list[0]
+    id_dict = { id_list[x]: x for x in range(len(id_list))}
+    id_dict[identity_string] = 0
+    #print('id_dict:', id_dict)
 
     res = []
     for family in PO.f:


### PR DESCRIPTION
The coefficient associated to the identity in 2^n dimensions, I^n, was zero if there were other Pauli strings with zero coefficient (because all the Pauli strings with zero coefficient are mapped to the identity, so when creating "id_dict", the id associated to I^n would be the last Pauli string transformed into the identity and not 0). I just proposed a quick solution. It can be improved later.